### PR TITLE
Bring linux build hack back

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,4 +1,15 @@
 #!/bin/bash
+
+if [[ $target_platform =~ linux.* ]]; then
+  # The vendored TBB library adds compile-time flags based on a probe of gcc,
+  # this little "hack" ensures that the `gcc` executable is available when
+  # TBB is built.
+  mkdir $PWD/hack
+  export PATH="$PWD/hack:$PATH"
+  ln -s $CC $PWD/hack/gcc
+  chmod +x $PWD/hack/gcc
+fi
+
 if [[ $target_platform =~ linux.* ]] || [[ $target_platform == win-32 ]] || [[ $target_platform == win-64 ]] || [[ $target_platform == osx-64 ]]; then
   export DISABLE_AUTOBREW=1
   $R CMD INSTALL --build .

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   merge_build_host: True  # [win]
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/


### PR DESCRIPTION
This was lost during recipe update.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
https://github.com/benjjneb/dada2/issues/684